### PR TITLE
Fix vercel not executing client loader for protected layout

### DIFF
--- a/app/routes/protected_layout.tsx
+++ b/app/routes/protected_layout.tsx
@@ -7,20 +7,9 @@ import type { Route } from './+types/protected_layout'
 // eslint-disable-next-line react-refresh/only-export-components
 export const clientLoader = async ({ request }: Route.ClientLoaderArgs) => {
   const userResult = await supabase.auth.getUser()
-  console.log('Obtained user')
-  console.log(userResult)
-
-  if (new URL(request.url).pathname.includes(appRoutes.petDetails)) {
-    console.log('Route matches exception')
-    console.log(request.url)
+  if (new URL(request.url).pathname.includes(appRoutes.petDetails))
     return userResult.data.user
-  }
-  if (userResult.error) {
-    console.log('Redirecting to login')
-    return redirect(appRoutes.login)
-  }
-
-  console.log('Navigation allowed')
+  if (userResult.error) return redirect(appRoutes.login)
   return userResult.data.user
 }
 


### PR DESCRIPTION
When checking for exception route `/pet`, the whole url was `https://pet-tracker.verc...`, so it was matched as exception even if pathname was not `/pet`.
To fix the issue, the whole request URL was parsed first to URL object and then the exception was done against `URL.pathname`.